### PR TITLE
[Automated] Pass explicit secrets to reusable workflow instead of inherit

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,6 +11,7 @@ jobs:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
     uses: ballerina-platform/ballerina-library/.github/workflows/pr-build-connector-template.yml@main
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       additional-test-flags: ${{ github.event.pull_request.head.repo.full_name != github.repository && '-x test' || ''}}


### PR DESCRIPTION
Replace `secrets: inherit` with the specific secrets this reusable workflow needs, instead of forwarding every secret available to this job.

Part of ballerina-platform/ballerina-library#8926